### PR TITLE
added support for the statement "import"

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,11 @@ var findImports = function(patterns, options) {
                     });
                     return;
                 }
+
+                if (node.type === 'ImportDeclaration') {
+                    addModule(modulePath, node.source.value);
+                    return;
+                }
             });
         } catch (e) {
             console.error('Error in `' + modulePath + '`: ' + e);


### PR DESCRIPTION
Hello.
I work on project, where we are use es6 notation.
And i want use module "find-imports" for defining imported dependencies.
But the current release of "find-imports" does not support the statement "import".
I forked you project and added support for the statement "import".